### PR TITLE
fix prefix and added Dave's suggestions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
     fi
 
 install:
-    - source install_ambertools.sh --prefix $HOME/amber16
+    - source install_ambertools.sh --prefix $HOME/
 
 script:
     - tleap -h

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -51,4 +51,4 @@ conda clean --all --yes
 echo ""
 echo "Make sure: "
 # absolute path
-echo "export PATH=`pwd -P $prefix/$amberfolder/bin`:\$PATH"
+echo "export PATH=$prefix/$amberfolder/bin:\$PATH"

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 version=16
+amberfolder='amber'$version
+set -e
 
 function print_help(){
     echo "bash install_ambertools.sh --prefix [your_desired_dir]"
@@ -29,22 +31,23 @@ else
     wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
 fi
 
-echo "Install Miniconda and AmberTools to $prefix"
+echo "Install Miniconda and AmberTools to $prefix/$amberfolder"
 echo ""
 
-bash miniconda.sh -b -p $prefix
+bash miniconda.sh -b -p $prefix/$amberfolder
 
-export PATH=$prefix/bin:$PATH
+export PATH=$prefix/$amberfolder/bin:$PATH
 conda update --all -y
 conda install --yes conda-build jinja2 pip cython numpy pytest
 conda install --yes ipython notebook
-$prefix/bin/pip install matplotlib # avoid qt
+$prefix/$amberfolder/bin/pip install matplotlib # avoid qt
 conda install --yes ipywidgets -c conda-forge
 conda install --yes nglview -c bioconda
 
 # TODO: change to ambermd channel
 conda install --yes ambertools=$version -c hainm
+conda clean --all --yes
 
 echo "Make sure to add PATH"
 echo ""
-echo "export PATH=$prefix:\$PATH"
+echo "export PATH=$prefix/$amberfolder/bin:\$PATH"

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -48,6 +48,7 @@ conda install --yes nglview -c bioconda
 conda install --yes ambertools=$version -c hainm
 conda clean --all --yes
 
-echo "Make sure to add PATH"
 echo ""
-echo "export PATH=$prefix/$amberfolder/bin:\$PATH"
+echo "Make sure: "
+# absolute path
+echo "export PATH=`pwd -P $prefix/$amberfolder/bin`:\$PATH"

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -38,7 +38,7 @@ bash miniconda.sh -b -p $prefix/$amberfolder
 
 export PATH=$prefix/$amberfolder/bin:$PATH
 conda update --all -y
-conda install --yes conda-build jinja2 pip cython numpy pytest
+conda install --yes conda-build jinja2 pip cython numpy nomkl pytest
 conda install --yes ipython notebook
 $prefix/$amberfolder/bin/pip install matplotlib # avoid qt
 conda install --yes ipywidgets -c conda-forge


### PR DESCRIPTION
- "prefix" should be what comes *before* the actual installation folder
```bash
   bash ./install_ambertools.sh --prefix /home/hai
   # create amber16 folder and install everything there
```
- not install `mkl` (to make the install faster). We don't use mkl anyway.
- should exit if getting error
- fix missing '/bin': "the export PATH statement in the last line is missing "/bin"
- conda clean