### PR TITLE
update script from Dave suggestion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,8 @@ script:
     - python -c "import pytraj; print(pytraj)"
     - python -c "import nglview; print(nglview)"   
 
+after_success:
+    - echo "hello there"
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 matrix:
   include:
     - { os: linux }
-    - { os: osx }
+    # - { os: osx }
 
 sudo: true
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Install Python and AmberTools binary distributions
 wget https://raw.githubusercontent.com/Amber-MD/setup-scripts/master/install_ambertools.sh
 
 # The script will create /home/amber16 folder and install everything there
-bash install_ambertools.sh --prefix /home/
+sh install_ambertools.sh --prefix /home/
 
 # The script will create /opt/amber16 folder and install everything there
-bash install_ambertools.sh --prefix /opt/
+sh install_ambertools.sh --prefix /opt/
 ```
 
 # adjust the script for your need

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -40,6 +40,11 @@ case "$1" in
         ;;
 esac
 
+if [ -d $prefix/$amberfolder ]; then
+    echo "ERROR: $prefix/$amberfolder already exists. Please change your prefix."
+    exit 1
+fi
+
 # should work for both osx and linux
 osname=`python -c 'import sys; print(sys.platform)'`
 if [ $osname = "darwin" ]; then

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -50,7 +50,7 @@ fi
 echo "Install Miniconda and AmberTools to $prefix/$amberfolder"
 echo ""
 
-sh miniconda.sh -b -p $prefix/$amberfolder
+bash miniconda.sh -b -p $prefix/$amberfolder
 
 export PATH=$prefix/$amberfolder/bin:$PATH
 conda update --all -y

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
 
+# TODO: specify version in command line
 version=16
 amberfolder='amber'$version
+channel='hainm'
+
 set -e
 
 function print_help(){
     echo "bash install_ambertools.sh --prefix [your_desired_dir]"
     exit
+}
+
+function message_source_amber(){
+    echo "--------------------------------------------------------------------------------"
+    echo "Environment resource files are provided to set the proper environment"
+    echo "variables to use AMBER and AmberTools. This is required to run any Python"
+    echo "programs (like MMPBSA.py, ParmEd, MCPB.py, and pytraj)"
+    echo ""
+    echo "If you use a Bourne shell (e.g., bash, sh, zsh, etc.), source the"
+    echo "$prefix/$amberfolder/amber.sh file in your shell. Consider adding the line"
+    echo "source $prefix/$amberfolder/amber.sh"
+    echo "to your startup file (e.g., ~/.bashrc)"
+    echo ""
 }
 
 while [ $# != 2 ]; do
@@ -34,7 +50,7 @@ fi
 echo "Install Miniconda and AmberTools to $prefix/$amberfolder"
 echo ""
 
-bash miniconda.sh -b -p $prefix/$amberfolder
+sh miniconda.sh -b -p $prefix/$amberfolder
 
 export PATH=$prefix/$amberfolder/bin:$PATH
 conda update --all -y
@@ -46,10 +62,21 @@ conda install --yes ipywidgets -c conda-forge
 conda install --yes nglview -c bioconda
 
 # TODO: change to ambermd channel
-conda install --yes ambertools=$version -c hainm
+conda install --yes ambertools=$version -c $channel
 conda clean --all --yes
 
-echo ""
-echo "Make sure: "
-# absolute path
-echo "export PATH=$prefix/$amberfolder/bin:\$PATH"
+# alias
+cd $prefix/$amberfolder
+ln -sf miniconda/bin/python amber.python || error "Linking Amber's Miniconda Python"
+ln -sf miniconda/bin/conda amber.conda || error "Linking Amber's Miniconda conda"
+ln -sf miniconda/bin/ipython amber.ipython || error "Linking Amber's Miniconda ipython"
+ln -sf miniconda/bin/jupyter amber.jupyter || error "Linking Amber's Miniconda jupyter"
+ln -sf miniconda/bin/pip amber.pip || error "Linking Amber's Miniconda pip"
+
+# Write resource files
+cat > $prefix/$amberfolder/amber.sh << EOF
+export AMBERHOME="$prefix/$amberfolder"
+export PATH="\${AMBERHOME}/bin:\${PATH}"
+EOF
+
+message_source_amber

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -21,8 +21,13 @@ function message_source_amber(){
     echo ""
     echo "If you use a Bourne shell (e.g., bash, sh, zsh, etc.), source the"
     echo "$amberhome/amber.sh file in your shell. Consider adding the line"
-    echo "source $amberhome/amber.sh"
+    echo "  source $amberhome/amber.sh"
     echo "to your startup file (e.g., ~/.bashrc)"
+    echo ""
+    echo "If you use a C shell (e.g., csh, tcsh), source the"
+    echo "$ambhome/amber.csh file in your shell. Consider adding the line"
+    echo "  source $ambhome/amber.csh"
+    echo "to your startup file (e.g., ~/.cshrc)"
     echo ""
 }
 

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -87,13 +87,14 @@ ln -sf pip amber.pip || error "Linking Amber's Miniconda pip"
 cd $cwd
 
 # Write resource files
+amberhome=`$prefix/$amberfolder/bin/python -c "import sys; print(sys.prefix)"`
 cat > $prefix/$amberfolder/amber.sh << EOF
-export AMBERHOME="$prefix/$amberfolder"
+export AMBERHOME="$amberhome"
 export PATH="\${AMBERHOME}/bin:\${PATH}"
 EOF
 
 cat > $prefix/$amberfolder/amber.csh << EOF
-setenv AMBERHOME "$prefix/$amberfolder"
+setenv AMBERHOME "$amberhome"
 setenv PATH "\${AMBERHOME}/bin:\${PATH}"
 EOF
 

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -13,14 +13,15 @@ function print_help(){
 }
 
 function message_source_amber(){
-    echo "--------------------------------------------------------------------------------"
+    amberhome=`$prefix/$amberfolder/bin/python -c "import sys; print(sys.prefix)"`
+    echo ""
+    echo "----------------------------------------------------------------------"
     echo "Environment resource files are provided to set the proper environment"
-    echo "variables to use AMBER and AmberTools. This is required to run any Python"
-    echo "programs (like MMPBSA.py, ParmEd, MCPB.py, and pytraj)"
+    echo "variables to use AMBER and AmberTools."
     echo ""
     echo "If you use a Bourne shell (e.g., bash, sh, zsh, etc.), source the"
-    echo "$prefix/$amberfolder/amber.sh file in your shell. Consider adding the line"
-    echo "source $prefix/$amberfolder/amber.sh"
+    echo "$amberhome/amber.sh file in your shell. Consider adding the line"
+    echo "source $amberhome/amber.sh"
     echo "to your startup file (e.g., ~/.bashrc)"
     echo ""
 }

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -25,8 +25,8 @@ function message_source_amber(){
     echo "to your startup file (e.g., ~/.bashrc)"
     echo ""
     echo "If you use a C shell (e.g., csh, tcsh), source the"
-    echo "$ambhome/amber.csh file in your shell. Consider adding the line"
-    echo "  source $ambhome/amber.csh"
+    echo "$amberhome/amber.csh file in your shell. Consider adding the line"
+    echo "  source $amberhome/amber.csh"
     echo "to your startup file (e.g., ~/.cshrc)"
     echo ""
 }

--- a/install_ambertools.sh
+++ b/install_ambertools.sh
@@ -66,17 +66,24 @@ conda install --yes ambertools=$version -c $channel
 conda clean --all --yes
 
 # alias
-cd $prefix/$amberfolder
-ln -sf miniconda/bin/python amber.python || error "Linking Amber's Miniconda Python"
-ln -sf miniconda/bin/conda amber.conda || error "Linking Amber's Miniconda conda"
-ln -sf miniconda/bin/ipython amber.ipython || error "Linking Amber's Miniconda ipython"
-ln -sf miniconda/bin/jupyter amber.jupyter || error "Linking Amber's Miniconda jupyter"
-ln -sf miniconda/bin/pip amber.pip || error "Linking Amber's Miniconda pip"
+cwd=`pwd`
+cd $prefix/$amberfolder/bin
+ln -sf python amber.python || error "Linking Amber's Miniconda Python"
+ln -sf conda amber.conda || error "Linking Amber's Miniconda conda"
+ln -sf ipython amber.ipython || error "Linking Amber's Miniconda ipython"
+ln -sf jupyter amber.jupyter || error "Linking Amber's Miniconda jupyter"
+ln -sf pip amber.pip || error "Linking Amber's Miniconda pip"
+cd $cwd
 
 # Write resource files
 cat > $prefix/$amberfolder/amber.sh << EOF
 export AMBERHOME="$prefix/$amberfolder"
 export PATH="\${AMBERHOME}/bin:\${PATH}"
+EOF
+
+cat > $prefix/$amberfolder/amber.csh << EOF
+setenv AMBERHOME "$prefix/$amberfolder"
+setenv PATH "\${AMBERHOME}/bin:\${PATH}"
 EOF
 
 message_source_amber


### PR DESCRIPTION
    1.  You need to check for the existence of $prefix/$amberfolder, and exit
        with a message if this already exists.


miniconda.sh already takes care of this. I added "set -e" so the script will exit if getting any error.
However, I still add checking from very beginning (before downloading miniconda.sh)
 


    2.  You should replace "bash" with "/bin/sh": not every machine will have
        bash, and it is not needed here.


sh miniconda.sh does not work on travis. So I still use "bash miniconda.sh" here.
 


    3.  The final message should be more explicit ("Make sure" is not as helpful
          as it could be.)  I think we should follow the source distribution,
          and have amber.sh and amber.csh scripts in the $prefix/$amberfolder
          directory.  Then we can ask users to just

              source $prefix/$amberfolder/amber.sh  (or amber.csh)


adding amber.sh and amber.csh too.

 

    4.  Generally, the goal is to have the environment for the binary distribution
    and the source distribution be as close as possible.  This implies that the
    python wrappers you have for tleap, antechamber, etc. should be put into the
    main git repo.


The python wrapper is dynamically created and it's already in main git repo:
AmberTools/src/conda-recipe/scripts/patch_amberhome/copy_and_post_process_bin.py